### PR TITLE
Traffic duplication removal (CIC-IDS-2017)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ the raw version of the dataset (PCAP file format).
 Then, first run [pcapfix](https://github.com/Rup0rt/pcapfix) and then [reordercap](https://www.wireshark.org/docs/man-pages/reordercap.html)
 on the PCAP files.
 
+For CIC-IDS-2017 files, remove the duplicated traffic of the original pcap files provided by the authors using the provided script and the following syntax : `./remove_traffic_duplication.sh PCAP_folder_in PCAP_folder_out`
+
 Then, run [our modified version of the CICFlowMeter tool](https://github.com/GintsEngelen/CICFlowMeter) on the data
 obtained in the previous step:
  

--- a/remove_traffic_duplication.sh
+++ b/remove_traffic_duplication.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if [ "$#" != "2" ]; then
+    echo "Usage : $0 pcap_folder output_folder"
+else
+    # Make sure folders exist
+    mkdir -p "$1"
+    mkdir -p "$2"
+
+    # Parameter
+    timewindow=0.000500
+
+    # Remove duplicated traffic with editcap
+    find "$1" -iname "*.pcap" | while read line; do editcap -w "$timewindow" "$line" "$2/$(basename $line)"; done
+fi


### PR DESCRIPTION
In [1], we discovered that CIC-IDS-2017 has some duplicated traffic. This pull request adds a script to remove duplicated traffic and modifies the README to include this step.

[1] Maxime Lanvin, Pierre-François Gimenez, Yufei Han, Frédéric Majorczyk, Ludovic Mé, et al.. Errors in the CICIDS2017 dataset and the significant differences in detection performances it makes. CRiSIS 2022 - International Conference on Risks and Security of Internet and Systems, Dec 2022, Sousse, Tunisia. pp.1-16. (https://hal.archives-ouvertes.fr/hal-03775466)